### PR TITLE
added support for google chrome driver, and new flags functionality

### DIFF
--- a/do_daily_check_in.bat
+++ b/do_daily_check_in.bat
@@ -1,12 +1,12 @@
+@echo off
+
 :: File: do_daily_check_in.bat 
-:: Version: 0.1.0 (for MS edge chromium)
+:: Version: 0.3.0 
 :: This batch file is used in case you want to set a windows task scheduler
 :: for the daily check-in bot that automatically runs the bot for you
 :: in the desired time.
-:: Note: make sure that the "msedgedriver.exe", and "script.py" files are in 
+:: Note: make sure that the web driver file and script file in 
 :: the same directory as the batch file.
-
-@echo off
 
 :: set the username
 set username=%1
@@ -14,12 +14,28 @@ set username=%1
 :: set the password
 set password=%2
 
-:: set MS edge driver file path
-set driverPath=%CD%\msedgedriver.exe
+:: set the flag option
+set flag=%3
+
+:: default flag value, if the user didn't specify a driver, google chrome is used
+IF NOT DEFINED flag set flag="-g" && set driverPath="chromedriver.exe" && goto next
+
+:: set driver file path according to the flag option
+IF "%flag%"=="-g" set driverPath="chromedriver.exe" 
+IF "%flag%"=="-e" set driverPath="msedgedriver.exe"
+
+:next
+:: if the driver file doesn't exist in the same directory exist batch.
+IF exist %driverPath% (
+	ECHO driver found = %driverPath% 
+	)ELSE (
+		echo no matching drivers in current directory.
+		exit /B 1
+		)
 
 :: looks for python launcher, and sets its absolute path on the user's machine
 set pythonPath=
 for /f "delims=" %%a in ('where python.exe') do @set pythonPath=%%a
 
 :: run the command
-"%pythonPath%" "%CD%\script.py" %username% %password% "%driverPath%"
+"%pythonPath%" "script.py" %username% %password% %flag% "%driverPath%"

--- a/script.py
+++ b/script.py
@@ -1,6 +1,6 @@
 """
 File: script.py
-Version: 0.1.2 (MS edge chromium)
+Version: 0.3.0
 Homepage: https://github.com/hema-001/Daily-check-in-bot
 
 This script automate the daily check-in process conducted by ZJNU students 
@@ -30,6 +30,7 @@ good health. Otherwise, the student should fill in the form according to his
 current health condition and traveling situation.
 """
 import sys
+from selenium import webdriver
 from msedge.selenium_tools import Edge, EdgeOptions
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
@@ -45,19 +46,32 @@ else:
 	
 	usernameStr = sys.argv[1]
 	passwordStr = sys.argv[2]
-	driverPath = sys.argv[3]
+	flag = sys.argv[3]
+	driverPath = sys.argv[4]
 
-	try:
-		# Launch Microsoft Edge (Chromium)
-		options = EdgeOptions()
-		options.use_chromium = True
-		browser = Edge(driverPath, options = options)
+	## flag options 
+	if flag == "-g":
+		try:
+			print(driverPath)
+			browser = webdriver.Chrome(driverPath)
+
+		except WebDriverException as err:
+			print(err)
+			exit()
+
+	elif flag == "-e":
+		try:
+			## Launch Microsoft Edge (Chromium)
+			options = EdgeOptions()
+			options.use_chromium = True
+			browser = Edge(driverPath, options = options)
 	
-	## If the user provides a wrong webdriver name.
-	except WebDriverException as err:
-		if "executable needs to be in PATH" in str(err):
-			print("\"{}\" doesn't exists, make sure you have typed the correct web driver name or path".format(driverPath))
-		exit()
+		## If the user provides a wrong webdriver name.
+		except WebDriverException as err:
+			if "executable needs to be in PATH" in str(err):
+				print("\"{}\" doesn't exists, make sure you have typed the correct web driver name or path".format(driverPath))
+			exit()
+	
 	
 	##enter the daily check-in website
 	browser.get(('http://zyt.zjnu.edu.cn/H5/Login.aspx?op=phone_html5'))


### PR DESCRIPTION
Users now can easily choose between two drivers, MS edge, or google chrome using the flag options `-g` for google chrome, and `-e` for MS edge.
Also, setting google chrome driver as the default driver (when running from batch file only) in case the user didn't specify an option, this design is preferred for two reasons; One, to make setting a task scheduler more flexible. Two, because the majority of internet users still use google chrome.

Note: when running the batch file (do_daily_check_in.bat), the user isn't required to specify the driver file name. However, running the script doesn't support a default value, so the user must specify the option flag, and the driver file name explicitly.